### PR TITLE
Changes to build.yml as per the lector remarks

### DIFF
--- a/HWL5-Ansible/build.yml
+++ b/HWL5-Ansible/build.yml
@@ -1,5 +1,5 @@
 ---
-- name: Clones PSamardzhiev repo, Builds an Docker Image, tag and upload it to DockerHub
+- name: Clone PSamardzhiev repo, build and run docker container and push the image to DockerHub
   hosts: localhost
   gather_facts: no
 
@@ -25,29 +25,26 @@
         dest: "{{ build_dir }}"
         clone: yes
 
-    - name: Build the container image
+    - name: Build and push the image
       community.docker.docker_image:
         name: "{{ image_name }}:{{ image_tag }}"
         source: build
         build:
           path: "{{ build_dir }}/"
+        name: "{{ image_name }}"
+        tag: "{{ image_tag }}"
+        repository: "{{ docker_repo }}"
+        push: true
+        source: build
         state: present
 
-    - name: Starta an container based on the image built from the previous task
+    - name: Start container based on the image built from the previous task
       community.docker.docker_container:
         name: "{{ cnt_name }}"
         image: "{{ image_name }}:{{ image_tag }}"
         state: started
         ports:
           - "{{ ports_map }}"
-
-    - name: Tag the compiled Docker Image with v0.2 tag and Push it to DockerHub public repo
-      community.docker.docker_image:
-        name: "{{ image_name }}"
-        tag: "{{ image_tag }}"
-        repository: "{{ docker_repo }}"
-        push: true
-        source: local
 
     - name: Clean up the temp build directory
       ansible.builtin.file:


### PR DESCRIPTION
removed the community.docker.docker_image re-use of the module, now the image build, tag and push are under one single 
ansible task as shown below:
---

```
 - name: Build and push the image
      community.docker.docker_image:
        name: "{{ image_name }}:{{ image_tag }}"
        source: build
        build:
          path: "{{ build_dir }}/"
        name: "{{ image_name }}"
        tag: "{{ image_tag }}"
        repository: "{{ docker_repo }}"
        push: true
        source: build
        state: present
```
Some of the build.yml tasks naming conventions have been changed to reflect the best practices.
